### PR TITLE
Beta 16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ikon"
-version = "0.1.0-beta.15"
+version = "0.1.0-beta.16"
 authors = [
     "Gark Garcia <gark.garcia@protonmail.com>",
     "Nicolas Girard <girard.nicolas@gmail.com>"

--- a/src/decode/error.rs
+++ b/src/decode/error.rs
@@ -49,11 +49,13 @@ impl From<io::Error> for DecodingError {
     }
 }
 
-impl Into<io::Error> for DecodingError {
-    fn into(self) -> io::Error {
-        match self {
-            Self::Io(err) => err,
-            Self::Unsupported(msg) => io::Error::new(io::ErrorKind::InvalidInput, msg)
+impl From<DecodingError> for io::Error {
+    fn from(err: DecodingError) -> io::Error {
+        match err {
+            DecodingError::Io(err) => err,
+            DecodingError::Unsupported(msg) => {
+                io::Error::new(io::ErrorKind::InvalidInput, msg)
+            }
         }
     }
 }

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -93,6 +93,7 @@ pub trait Decode<'a>: Sized {
     fn contains_icon(&self, icon: &Self::Icon) -> bool;
     
     /// Returns `Some(icon)` if the icon family contains `icon`.
+    /// Otherwise returns `None`.
     fn get(&self, icon: &Self::Icon) -> Option<&Image>;
 
     /// Returns an iterator that iterates through all icons contained in 

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -1,4 +1,4 @@
-//! Traits, types and functions to assist in dencoding commonly used 
+//! Traits, types and functions to assist in decoding commonly used 
 //! _icon formats_.
 
 use crate::{load_raster, load_vector, Icon, Image};
@@ -22,12 +22,11 @@ mod error;
 /// #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 /// pub struct Icon(pub u16);
 /// 
-/// impl Icon for ikon::Icon {
-///     fn size(&self) -> u32 {
-///         if self.0 == 0 {
-///             256
-///         } else {
-///             *self.0
+/// impl ikon::Icon for Icon {
+///     fn size(&self) -> (u32, u32) {
+///         match self {
+///             Icon(0) => (256, 256),
+///             Icon(size) => (*size as u32, *size as u32)
 ///         }
 ///     }
 /// }
@@ -37,93 +36,56 @@ mod error;
 /// `IconFamily` type.
 /// 
 /// ```rust
+/// use std::{io::{self, Read}, collections::HashMap, hash::Hash, slice::Iter};
+/// use ikon::{decode::{Decode, DecodingError}, Image};
+///
 /// #[derive(Clone)]
-/// pub struct IconFamily {
-///     internal: HashMap<Icon, DynamicImage>
+/// pub struct IconFamily<Icon: ikon::Icon + Send + Sync + Eq + Hash> {
+///     internal: HashMap<Icon, Image>
 /// }
 /// 
-/// impl Decode for IconFamily {
+/// impl<'a, Icon> Decode<'a> for IconFamily<Icon> 
+///     where Icon: 'a + ikon::Icon + Send + Sync + Eq + Hash
+/// {
 ///     type Icon = Icon;
+///     type Icons = Iter<'a, (Self::Icon, Image)>;
 /// 
-///     fn read<R: Read>(r: R) -> io::Result<Self> {
-///         // Some decoding in here . . .
+///     fn read<R: Read>(r: R) -> Result<Self, DecodingError> {
+///         unimplemented!("Some decoding in here . . .");
 ///     }
 /// 
 ///     fn len(&self) -> usize {
 ///         self.internal.len()
 ///     }
 /// 
-///     fn contains_icon(icon: &Self::Icon) -> bool {
-///         self.internal.contains_entry(icon)
+///     fn contains_icon(&self, icon: &Self::Icon) -> bool {
+///         self.internal.contains_key(icon)
 ///     }
 /// 
 ///     fn get(&self, icon: &Self::Icon) -> Option<&Image> {
 ///         self.internal.get(icon)
 ///     }
-/// 
-///     fn icons(&self) -> Iter<(Self::Icon, Image)> {
-///         let output = Vec::with_capacity(self.len());
-/// 
-///         for icon in self.internal {
-///             output.push(icon);
-///         }
-/// 
-///         output.iter()
-///     }
 /// }
 /// ```
 pub trait Decode<'a>: Sized {
+    /// The type of icon of the icon family.
     type Icon: 'a + Icon + Send + Sync;
-    type Icons: Iterator<Item = (&'a Self::Icon, &'a Image)>;
+
+    /// The return type of `Decode::icons`.
+    type Icons: Iterator<Item = &'a (Self::Icon, Image)>;
 
     /// Parses and loads an icon family into memmory.
     fn read<R: Read + Seek>(r: R) -> Result<Self, DecodingError>;
 
     /// Returns the number of _icons_ contained in the icon family.
-    /// 
-    /// # Example
-    /// 
-    /// ```rust
-    /// let len = icon.len();
-    /// ```
     fn len(&self) -> usize;
 
     /// Returns `true` if the icon family contains `icon`.
     /// Otherwise returns `false`.
-    /// 
-    /// # Example
-    /// 
-    /// ```rust
-    /// if icon.contains_icon(&Icon(32)) {
-    ///     // Do this . . .
-    /// } else {
-    ///     // Do that . . .
-    /// }
-    /// ```
     fn contains_icon(&self, icon: &Self::Icon) -> bool;
     
     /// Returns `Some(icon)` if the icon family contains `icon`.
-    /// Otherwise returns `None`.
-    /// 
-    /// # Example
-    /// 
-    /// ```rust
-    /// if let Some(icon) = icon.icon(&Icon(32)) {
-    ///     // Process the icon . . .
-    /// }
-    /// ```
     fn get(&self, icon: &Self::Icon) -> Option<&Image>;
-
-    /// Returns an iterator over the icons of the icon family.
-    /// 
-    /// # Example
-    /// 
-    /// ```rust
-    /// for (icon, image) in icon.icons() {
-    ///     // Do something . . .
-    /// }
-    /// ```
-    fn icons(&'a self) -> Self::Icons;
 }
 
 #[inline]

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -36,7 +36,11 @@ mod error;
 /// `IconFamily` type.
 /// 
 /// ```rust
-/// use std::{io::{self, Read}, collections::HashMap, hash::Hash, slice::Iter};
+/// use std::{
+///     io::{self, Read}, 
+///     collections::hash_map::{HashMap, Iter}, 
+///     hash::Hash
+/// };
 /// use ikon::{decode::{Decode, DecodingError}, Image};
 ///
 /// #[derive(Clone)]
@@ -48,7 +52,7 @@ mod error;
 ///     where Icon: 'a + ikon::Icon + Send + Sync + Eq + Hash
 /// {
 ///     type Icon = Icon;
-///     type Icons = Iter<'a, (Self::Icon, Image)>;
+///     type Iter = Iter<'a, Icon, Image>;
 /// 
 ///     fn read<R: Read>(r: R) -> Result<Self, DecodingError> {
 ///         unimplemented!("Some decoding in here . . .");
@@ -65,14 +69,18 @@ mod error;
 ///     fn get(&self, icon: &Self::Icon) -> Option<&Image> {
 ///         self.internal.get(icon)
 ///     }
+///
+///     fn iter(&'a self) -> Self::Iter {
+///         self.internal.iter()
+///     }
 /// }
 /// ```
 pub trait Decode<'a>: Sized {
     /// The type of icon of the icon family.
     type Icon: 'a + Icon + Send + Sync;
 
-    /// The return type of `Decode::icons`.
-    type Icons: Iterator<Item = &'a (Self::Icon, Image)>;
+    /// The return type of `Decode::iter`.
+    type Iter: Iterator<Item = (&'a Self::Icon, &'a Image)>;
 
     /// Parses and loads an icon family into memmory.
     fn read<R: Read + Seek>(r: R) -> Result<Self, DecodingError>;
@@ -86,6 +94,10 @@ pub trait Decode<'a>: Sized {
     
     /// Returns `Some(icon)` if the icon family contains `icon`.
     fn get(&self, icon: &Self::Icon) -> Option<&Image>;
+
+    /// Returns an iterator that iterates through all icons contained in 
+    /// `self`.
+    fn iter(&'a self) -> Self::Iter;
 }
 
 #[inline]

--- a/src/encode/error.rs
+++ b/src/encode/error.rs
@@ -68,12 +68,12 @@ impl<I: Icon + Send + Sync> From<io::Error> for EncodingError<I> {
     }
 }
 
-impl<I: Icon + Send + Sync> Into<io::Error> for EncodingError<I> {
-    fn into(self) -> io::Error {
-        if let Self::Resample(err) = self {
+impl<I: Icon + Send + Sync> From<EncodingError<I>> for io::Error {
+    fn from(err: EncodingError<I>) -> io::Error {
+        if let EncodingError::Resample(err) = err {
             err.into()
         } else {
-            io::Error::new(io::ErrorKind::InvalidInput, format!("{}", self))
+            io::Error::new(io::ErrorKind::InvalidInput, format!("{}", err))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,11 +86,6 @@ impl Image {
     /// * Returns `Err(io::Error::from(io::ErrorKind::InvalidInput))` if the image format is not
     ///   supported by `ikon`.
     /// * Returns `Err(io::Error::from(io::ErrorKind::InvalidData))` otherwise.
-    ///
-    /// # Example
-    /// ```rust
-    /// let img = Image::open("source.png")?;
-    /// ```
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, io::Error> {
         Self::load(File::open(path)?)
     }
@@ -105,12 +100,6 @@ impl Image {
     /// * Returns `Err(io::Error::from(io::ErrorKind::InvalidInput))` if the image format is not
     ///   supported by `ikon`.
     /// * Returns `Err(io::Error::from(io::ErrorKind::InvalidData))` otherwise.
-    ///
-    /// # Example
-    /// ```rust
-    /// let file = File::open("source.png")?;
-    /// let img = Image::load(file)?;
-    /// ```
     pub fn load<R: Read + Seek>(mut read: R) -> Result<Self, io::Error> {
         // Read the file's signature
         let mut signature: [u8;8] = [0;8];
@@ -145,14 +134,6 @@ impl Image {
     /// rasterizes the image to fit the dimensions specified `size` using
     /// [_linear interpolation_](https://en.wikipedia.org/wiki/Linear_interpolation)
     /// and [_anti-aliasing_](https://en.wikipedia.org/wiki/Anti-aliasing).
-    /// 
-    /// # Example
-    /// 
-    /// ```rust
-    /// if let Ok(raster) = image.rasterize(resample::linear, 32) {
-    ///     // Process raster...
-    /// }
-    /// ```
     pub fn rasterize<F: FnMut(&DynamicImage, (u32, u32)) -> io::Result<DynamicImage>>(
         &self,
         filter: F,
@@ -249,7 +230,9 @@ fn load_vector<R: Read + Seek>(mut read: R) -> io::Result<Tree> {
         Err(usvg::Error::InvalidFileSuffix) => {
             Err(io::Error::from(io::ErrorKind::InvalidInput))
         }
-        Err(usvg::Error::FileOpenFailed) => Err(io::Error::from(io::ErrorKind::Other)),
+        Err(usvg::Error::FileOpenFailed) => {
+            Err(io::Error::from(io::ErrorKind::Other))
+        },
         _ => Err(io::Error::from(io::ErrorKind::InvalidData)),
     }
 }

--- a/src/resample/error.rs
+++ b/src/resample/error.rs
@@ -47,11 +47,13 @@ impl Error for ResampleError {
     }
 }
 
-impl Into<io::Error> for ResampleError {
-    fn into(self) -> io::Error {
-        match self {
-            Self::Io(err) => err,
-            Self::MismatchedDimensions(_, _) => io::Error::from(io::ErrorKind::InvalidData),
+impl From<ResampleError> for io::Error {
+    fn from(err: ResampleError) -> io::Error {
+        match err {
+            ResampleError::Io(err) => err,
+            ResampleError::MismatchedDimensions(_, _) => {
+                io::Error::from(io::ErrorKind::InvalidData)
+            }
         }
     }
 }


### PR DESCRIPTION
Implemented `From<error type> for io::Error` for all error types in the crate.

Deprecated the implementations of `Into<io::Error>` for those error types. This is made possible by the flexibilization of `impl` patterns in Rust 1.42.